### PR TITLE
update Flutter CI to checkout v3

### DIFF
--- a/.github/workflows/flutter-pr.yaml
+++ b/.github/workflows/flutter-pr.yaml
@@ -17,7 +17,7 @@ jobs:
         working-directory: mobile
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Flutter action
         uses: subosito/flutter-action@v2.3.0


### PR DESCRIPTION
update Flutter CI to checkout v3 to fix the following warning:
```
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2. 
For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
```
